### PR TITLE
V2.8.0 ben

### DIFF
--- a/schema/AU1.3/example.sql
+++ b/schema/AU1.3/example.sql
@@ -56,7 +56,7 @@ CREATE TABLE IF NOT EXISTS SchoolInfo (
 -- OtherIdList/OtherId
 
 CREATE TABLE IF NOT EXISTS StudentPersonal (
-	RefId varchar(36) UNIQUE,
+	RefId varchar(36) PRIMARY KEY,
 	LocalId varchar(200),
 	FamilyName varchar(2000),
 	GivenName varchar(2000),
@@ -113,11 +113,14 @@ CREATE TABLE IF NOT EXISTS StudentPersonal (
 	OtherIdType Varchar(200),
 	Religion VARCHAR(200),
 	PreferredFamilyName Varchar(2000),
+	ESLSupport VARCHAR(20) NULL,
+	InterpreterRequired VARCHAR(20) null,
 	FOREIGN KEY (SchoolInfo_RefId) REFERENCES SchoolInfo(RefId)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
 CREATE TABLE IF NOT EXISTS StudentPersonal_OtherId (
+	Id MEDIUMINT PRIMARY KEY NOT NULL AUTO_INCREMENT,
 	StudentPersonal_RefId varchar(36) DEFAULT NULL,
 	OtherId varchar(200) DEFAULT NULL,
 	OtherIdType varchar(200) DEFAULT NULL,
@@ -152,24 +155,80 @@ CREATE TABLE IF NOT EXISTS Language (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
-CREATE TABLE IF NOT EXISTS StudentSchoolEnrollment (
-	RefId varchar(36) UNIQUE,
-	StudentPersonal_RefId varchar(36),
-	SchoolInfo_RefId varchar(36),
-	MembershipType varchar(10),
-	SchoolYear varchar(10),
-	TimeFrame varchar(10),
-	YearLevel varchar(10),
-	FTE varchar(5),
-	EntryDate varchar(25),
-	ExitDate Varchar(25),
-	RecordClosureReason VARCHAR(200),
-	PromotionStatus VARCHAR(200),
-	ClassCode varchar(200),
-	ReportingSchool varchar(200),
-	FOREIGN KEY (SchoolInfo_RefId) REFERENCES SchoolInfo(RefId),
-	FOREIGN KEY (StudentPersonal_RefId) REFERENCES StudentPersonal(RefId)
+CREATE TABLE `StudentSchoolEnrollment` (
+  `RefId` varchar(36) NOT NULL,
+  `StudentPersonal_RefId` varchar(36) DEFAULT NULL,
+  `SchoolInfo_RefId` varchar(36) DEFAULT NULL,
+  `MembershipType` varchar(10) DEFAULT NULL,
+  `SchoolYear` varchar(10) DEFAULT NULL,
+  `TimeFrame` varchar(10) DEFAULT NULL,
+  `YearLevel` varchar(10) DEFAULT NULL,
+  `FTE` varchar(5) DEFAULT NULL,
+  `EntryDate` varchar(25) DEFAULT NULL,
+  `ExitDate` varchar(25) DEFAULT NULL,
+  `RecordClosureReason` varchar(200) DEFAULT NULL,
+  `PromotionStatus` varchar(200) DEFAULT NULL,
+  `ClassCode` varchar(200) DEFAULT NULL,
+  `ReportingSchool` varchar(200) DEFAULT NULL,
+  `LocalId` varchar(200) DEFAULT NULL,
+  `EntryType` varchar(200) DEFAULT NULL,
+  `Homeroom_RefId` varchar(36) DEFAULT NULL,
+  `Advisor_RefId` varchar(36) DEFAULT NULL,
+  `Counselor_RefId` varchar(36) DEFAULT NULL,
+  `Homegroup` varchar(200) DEFAULT NULL,
+  `AcaraSchoolId` varchar(200) DEFAULT NULL,
+  `TestLevel` varchar(200) DEFAULT NULL,
+  `House` varchar(200) DEFAULT NULL,
+  `IndividualLearningPlan` varchar(20) DEFAULT NULL,
+  `Calendar_RefId` varchar(36) DEFAULT NULL,
+  `ExitStatus` varchar(20) DEFAULT NULL,
+  `ExitType` varchar(20) DEFAULT NULL,
+  `FTPTStatus` varchar(20) DEFAULT NULL,
+  `FFPOS` varchar(20) DEFAULT NULL,
+  `CatchmentStatus` varchar(20) DEFAULT NULL,
+  `PreviousSchool` varchar(200) DEFAULT NULL,
+  `PreviousSchoolName` varchar(200) DEFAULT NULL,
+  `DestinationSchool` varchar(200) DEFAULT NULL,
+  `DestinationSchoolName` varchar(200) DEFAULT NULL,
+  `StartedAtSchoolDate` varchar(25) DEFAULT NULL,
+  PRIMARY KEY (`RefId`),
+  KEY `StudentSchoolEnrollment_StudentPersonal_RefId_IX` (`StudentPersonal_RefId`),
+  KEY `StudentSchoolEnrollment_SchoolInfo_RefId_IX` (`SchoolInfo_RefId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE StudentSchoolEnrollment_PublishingPermission (
+   ID INT(11) NOT NULL AUTO_INCREMENT,
+   StudentSchoolEnrollment_RefId VARCHAR(36) NOT NULL,
+   PermissionCategory VARCHAR(200),
+   PermissionValue VARCHAR(200),
+   PRIMARY KEY (id),
+   INDEX SSE_PublishingPermission_IX (StudentSchoolEnrollment_RefId),
+   CONSTRAINT SSE_PublishingPermission_FK FOREIGN KEY (StudentSchoolEnrollment_RefId) REFERENCES StudentSchoolEnrollment (RefId)
+) Engine=InnoDB DEFAULT Charset=utf8;
+
+CREATE TABLE StudentSchoolEnrollment_StudentGroup (
+   ID INT(11) NOT NULL AUTO_INCREMENT,
+   StudentSchoolEnrollment_RefId VARCHAR(36) NOT NULL,
+   GroupCategory VARCHAR(200),
+   GroupLocalId VARCHAR(200),
+   GroupDescription VARCHAR(2000),
+   PRIMARY KEY (id),
+   INDEX SSE_StudentGroup_IX (StudentSchoolEnrollment_RefId),
+   CONSTRAINT SSE_StudentGroup_FK FOREIGN KEY (StudentSchoolEnrollment_RefId) REFERENCES StudentSchoolEnrollment (RefId)
+) Engine=InnoDB DEFAULT Charset=utf8;
+
+CREATE TABLE StudentSchoolEnrollment_StudentSubjectChoice (
+   ID INT(11) NOT NULL AUTO_INCREMENT,
+   StudentSchoolEnrollment_RefId VARCHAR(36) NOT NULL,
+   PreferenceNumber VARCHAR(200),
+   SubjectLocalId VARCHAR(200),
+   StudyDescription VARCHAR(200),
+   OtherSchoolLocalId VARCHAR(200),
+   PRIMARY KEY (id),
+   UNIQUE INDEX SSE_StudentSubjectChoice_PKX (ID),
+   INDEX SSE_StudentSubjectChoice_IX (StudentSchoolEnrollment_RefId),
+   CONSTRAINT SSE_StudentSubjectChoice_FK FOREIGN KEY (StudentSchoolEnrollment_RefId) REFERENCES StudentSchoolEnrollment (RefId)
+) Engine=InnoDB DEFAULT Charset=utf8;
 
 CREATE TABLE IF NOT EXISTS StaffPersonal (
 	RefId varchar(36) UNIQUE,
@@ -194,7 +253,7 @@ CREATE TABLE IF NOT EXISTS StaffPersonal (
 	MostRecent_SchoolACARAId varchar(200),
 	MostRecent_SchoolLocalId varchar(200),
 	MostRecent_LocalCampusId varchar(200),
-
+	InterpreterRequired VARCHAR(20) null,
 	FOREIGN KEY (SchoolInfo_RefId) REFERENCES SchoolInfo(RefId)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -239,20 +298,56 @@ CREATE TABLE IF NOT EXISTS Address (
 	-- XXX join to StudentPersonal or StaffPersonal or StudentContactPersonal...
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-CREATE TABLE IF NOT EXISTS StaffAssignment (
-	RefId varchar(36) UNIQUE,
-	SchoolInfo_RefId varchar(36),
-	SchoolYear varchar(200),
-	StaffPersonal_RefId varchar(36),
-	Description varchar(200),
-	PrimaryAssignment varchar(200),
-	JobStartDate varchar(200),
-	JobEndDate varchar(200),
-	JobFunction varchar(200),
-	StaffActivity_Code varchar(200),
-	FOREIGN KEY (SchoolInfo_RefId) REFERENCES SchoolInfo(RefId),
-	FOREIGN KEY (StaffPersonal_RefId) REFERENCES StaffPersonal(RefId)
+CREATE TABLE `StaffAssignment` (
+  `RefId` varchar(36) NOT NULL,
+  `SchoolInfo_RefId` varchar(36) DEFAULT NULL,
+  `SchoolYear` varchar(200) DEFAULT NULL,
+  `StaffPersonal_RefId` varchar(36) DEFAULT NULL,
+  `Description` varchar(200) DEFAULT NULL,
+  `PrimaryAssignment` varchar(200) DEFAULT NULL,
+  `JobStartDate` varchar(200) DEFAULT NULL,
+  `JobEndDate` varchar(200) DEFAULT NULL,
+  `JobFunction` varchar(200) DEFAULT NULL,
+  `StaffActivity_Code` varchar(200) DEFAULT NULL,
+  `JobFTE` varchar(20) DEFAULT NULL,
+  `EmploymentStatus` varchar(20) DEFAULT NULL,
+  `CasualReliefTeacher` varchar(20) DEFAULT NULL,
+  `Homegroup` varchar(200) DEFAULT NULL,
+  `House` varchar(200) DEFAULT NULL,
+  `PreviousSchoolName` varchar(200) DEFAULT NULL,
+  PRIMARY KEY (`RefId`),
+  KEY `SchoolInfo_RefId_IX` (`SchoolInfo_RefId`),
+  KEY `StaffPersonal_RefId_IX` (`StaffPersonal_RefId`),
+  CONSTRAINT `StaffAssignment_ibfk_1` FOREIGN KEY (`SchoolInfo_RefId`) REFERENCES `SchoolInfo` (`RefId`),
+  CONSTRAINT `StaffAssignment_ibfk_2` FOREIGN KEY (`StaffPersonal_RefId`) REFERENCES `StaffPersonal` (`RefId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE StaffAssignment_YearLevel (
+   StaffAssignment_RefId VARCHAR(36) NOT NULL,
+   YearLevel VARCHAR(20) NOT NULL,
+   PRIMARY KEY (StaffAssignment_RefId, YearLevel),
+   INDEX SA_YearLevel_FKX (StaffAssignment_RefId),
+   CONSTRAINT SA_YearLevel_FK FOREIGN KEY (StaffAssignment_RefId) REFERENCES StaffAssignment (RefId)
+) Engine=InnoDB DEFAULT Charset=utf8;
+
+CREATE TABLE StaffAssignment_CalendarSummary (
+   StaffAssignment_RefId VARCHAR(36) NOT NULL,
+   CalendarSummary_RefId VARCHAR(36) NOT NULL,
+   PRIMARY KEY (StaffAssignment_RefId, CalendarSummary_RefId),
+   INDEX SA_CalendarSummary_FKX (StaffAssignment_RefId),
+   CONSTRAINT SA_CalendarSummary_FK FOREIGN KEY (StaffAssignment_RefId) REFERENCES StaffAssignment (RefId)
+) Engine=InnoDB DEFAULT Charset=utf8;
+
+CREATE TABLE StaffAssignment_StaffSubject (
+   ID INT(11) NOT NULL AUTO_INCREMENT,
+   StaffAssignment_RefId VARCHAR(36) NOT NULL,
+   PreferenceNumber VARCHAR(200),
+   SubjectLocalId VARCHAR(200),
+   TimeTableSubject_RefId VARCHAR(36),
+   PRIMARY KEY (id),
+   INDEX SA_StaffSubject_IX (StaffAssignment_RefId),
+   CONSTRAINT SA_StaffSubject_FK FOREIGN KEY (StaffAssignment_RefId) REFERENCES StaffAssignment (RefId)  
+) Engine=InnoDB DEFAULT Charset=utf8;
 
 CREATE TABLE IF NOT EXISTS StudentContactPersonal (
 	RefId VARCHAR(36) UNIQUE,
@@ -270,7 +365,8 @@ CREATE TABLE IF NOT EXISTS StudentContactPersonal (
 	EmailType VARCHAR(200),
 	SchoolEducationLevel VARCHAR(200),
 	NonSchoolEducation VARCHAR(200),
-	EmploymentType VARCHAR(200)
+	EmploymentType VARCHAR(200),
+	InterpreterRequired VARCHAR(20) null
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS StudentContactRelationship (
@@ -664,6 +760,7 @@ CREATE TABLE IF NOT EXISTS StudentAttendanceTimeList_AttendanceTime (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS StudentAttendanceTimeList_AttendanceTime_OtherCode (
+	Id MEDIUMINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
 	StudentAttendanceTimeList_AttendanceTime_id MEDIUMINT NOT NULL,
 	OtherCode varchar(100),
 	OtherCode_CodeSet varchar(100),
@@ -789,7 +886,9 @@ CREATE TABLE IF NOT EXISTS VendorInfo (
 	BPay VARCHAR(200),
 	BSB VARCHAR(200),
 	AccountNumber  VARCHAR(200),
-	AccountName  VARCHAR(200)
+	AccountName  VARCHAR(200),
+    ContactInfo_Qualifications VARCHAR(200) NULL,
+    ContactInfo_RegistrationDetails VARCHAR(200) NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS PaymentReceipt (
@@ -895,15 +994,26 @@ CREATE TABLE IF NOT EXISTS GradingAssignmentScore (
 	FOREIGN KEY (GradingAssignment_RefId) REFERENCES GradingAssignment(RefId)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-CREATE TABLE PersonPicture (
-	RefId VARCHAR(36),
-	ParentObject_RefId VARCHAR(36),
-	ParentObjectRefId_SIF_RefObject VARCHAR(200),
-	SchoolYear varchar(200),
-	PictureSource TEXT,
-	PictureSourceType varchar(200),
-	OKToPublish varchar(200)
+CREATE TABLE `PersonPicture` (
+  `RefId` varchar(36) NOT NULL,
+  `ParentObject_RefId` varchar(36) DEFAULT NULL,
+  `ParentObjectRefId_SIF_RefObject` varchar(200) DEFAULT NULL,
+  `SchoolYear` varchar(200) DEFAULT NULL,
+  `PictureSource` text DEFAULT NULL,
+  `PictureSourceType` varchar(200) DEFAULT NULL,
+  `OKToPublish` varchar(200) DEFAULT NULL,
+  PRIMARY KEY (`RefId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE PersonPicture_PublishingPermission (
+   ID INT(11) NOT NULL AUTO_INCREMENT,
+   PersonPicture_RefId VARCHAR(36) NOT NULL,
+   PermissionCategory VARCHAR(200),
+   PermissionValue VARCHAR(200),
+   PRIMARY KEY (id),
+   INDEX PP_PublishingPermission_IX (PersonPicture_RefId),
+   CONSTRAINT PP_PublishingPermission_FK FOREIGN KEY (PersonPicture_RefId) REFERENCES PersonPicture (RefId)
+) Engine=InnoDB DEFAULT Charset=utf8;
 
 -- NAPLAN start
 CREATE TABLE `NAPTest` (
@@ -1571,7 +1681,43 @@ CREATE TABLE TimeTableCell_TeacherCover (
     Weighting VARCHAR(200)
 )  ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-create table FQReporting (
+CREATE TABLE AGStatusReport (
+   RefId VARCHAR(36) NOT NULL PRIMARY KEY,
+   ReportingAuthority VARCHAR(200),
+   ReportingAuthoritySystem VARCHAR(200),
+   ReportingAuthorityCommonwealthId VARCHAR(200),
+   SubmittedBy VARCHAR(200),
+   SubmissionTimestamp VARCHAR(200),
+   AGCollection VARCHAR(200),
+   CollectionYear VARCHAR(200)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE AGStatusReport_ReportingObjectResponse (
+   Id MEDIUMINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+   AGStatusReport_RefId VARCHAR(36) NOT NULL,
+   SubmittedRefId VARCHAR(36),
+   SIFRefId VARCHAR(36),
+   HTTPStatusCode VARCHAR(200),
+   ErrorText VARCHAR(200),
+   CommonwealthId VARCHAR(200),
+   EntityName VARCHAR(200),
+   AGSubmissionStatusCode VARCHAR(200),
+   INDEX `ReportingObjectResponse_AGStatusReport_IX` (`AGStatusReport_RefId`),
+   CONSTRAINT `ReportingObjectResponse_AGStatusReport_FK` FOREIGN KEY (`AGStatusReport_RefId`) REFERENCES `AGStatusReport` (`RefId`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE AGStatusReport_AGRule (
+   Id MEDIUMINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+   ReportingObjectResponse_Id MEDIUMINT NOT NULL,
+   AGRuleCode VARCHAR(200),
+   AGRuleComment VARCHAR(200),
+   AGRuleResponse VARCHAR(200),
+   AGRuleStatus VARCHAR(200),
+   INDEX `Rule_ReportingObjectResponse_IX` (`ReportingObjectResponse_Id`),
+   CONSTRAINT `Rule_ReportingObjectResponse_FK` FOREIGN KEY (`ReportingObjectResponse_Id`) REFERENCES `AGStatusReport_ReportingObjectResponse` (`Id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+create table FinancialQuestionnaireSubmission (
   RefId varchar(36) NOT NULL,
   FQYear varchar(200) DEFAULT NULL,
   ReportingAuthority varchar(200) DEFAULT NULL,
@@ -1580,19 +1726,13 @@ create table FQReporting (
   SystemSubmission varchar(200) DEFAULT NULL,
   SoftwareVendorInfo_SoftwareProduct varchar(200) DEFAULT NULL,
   SoftwareVendorInfo_SoftwareVersion varchar(200) DEFAULT NULL,
-  EntityLevel varchar(200) DEFAULT NULL,
-  SchoolInfo_RefId varchar(36) DEFAULT NULL,
-  LocalId varchar(200) DEFAULT NULL,
-  StateProvinceId varchar(200) DEFAULT NULL,
-  CommonwealthId varchar(200) DEFAULT NULL,
-  AcaraId varchar(200) DEFAULT NULL,
-  EntityName varchar(200) DEFAULT NULL,
-PRIMARY KEY (RefId)
+  FQReportComments varchar(200) DEFAULT NULL,
+  PRIMARY KEY (RefId)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-create table FQReporting_EntityContact (
+create table FQSubmission_EntityContact (
   id MEDIUMINT AUTO_INCREMENT PRIMARY KEY,
-  FQReporting_RefId varchar(36) NOT NULL,
+  FQSubmission_RefId varchar(36) NOT NULL,
   PositionTitle varchar(200) DEFAULT NULL,
   Role varchar(200) DEFAULT NULL,
   RegistrationDetails varchar(200) DEFAULT NULL,
@@ -1603,7 +1743,106 @@ create table FQReporting_EntityContact (
   PhoneNumber_Number varchar(200) DEFAULT NULL,
   PhoneNumber_Extension varchar(200) DEFAULT NULL,
   PhoneNumber_ListedStatus varchar(200) DEFAULT NULL,
-  PhoneNumber_Preference varchar(200) DEFAULT NULL
+  PhoneNumber_Preference varchar(200) DEFAULT NULL,
+  INDEX `EntityContact_FQSubmission_IX` (`FQSubmission_RefId`),
+  CONSTRAINT `EntityContact_FQSubmission_FK` FOREIGN KEY (`FQSubmission_RefId`) REFERENCES `FinancialQuestionnaireSubmission` (`RefId`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+create table FQSubmission_EntityContact_Name (
+  id MEDIUMINT AUTO_INCREMENT PRIMARY KEY,
+  FQSubmission_EntityContact_Id MEDIUMINT NOT NULL,
+  NameType varchar(200) DEFAULT NULL,
+  Title varchar(200) DEFAULT NULL,
+  FamilyName varchar(200) DEFAULT NULL,
+  GivenName varchar(200) DEFAULT NULL,
+  MiddleName varchar(200) DEFAULT NULL,
+  FamilyNameFirst varchar(200) DEFAULT NULL,
+  PreferredFamilyName varchar(200) DEFAULT NULL,
+  PreferredFamilyNameFirst varchar(200) DEFAULT NULL,
+  PreferredGivenName varchar(200) DEFAULT NULL,
+  Suffix varchar(200) DEFAULT NULL,
+  FullName varchar(200) DEFAULT NULL,
+  INDEX `Name_FQSubmissionEntityContact_IX` (`FQSubmission_EntityContact_Id`),
+  CONSTRAINT `Name_FQSubmissionEntityContact_FK` FOREIGN KEY (`FQSubmission_EntityContact_Id`) REFERENCES `FQSubmission_EntityContact` (`Id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+create table FQSubmission_EntityContact_Address (
+  id MEDIUMINT AUTO_INCREMENT PRIMARY KEY,
+  FQSubmission_EntityContact_Id MEDIUMINT NOT NULL,
+  AddressType varchar(200) DEFAULT NULL,
+  AddressRole varchar(200) DEFAULT NULL,
+  EffectiveFromDate varchar(200) DEFAULT NULL,
+  EffectiveToDate varchar(200) DEFAULT NULL,
+  Street_Line1 varchar(200) DEFAULT NULL,
+  Street_Line2 varchar(200) DEFAULT NULL,
+  Street_Line3 varchar(200) DEFAULT NULL,
+  Street_Complex varchar(200) DEFAULT NULL,
+  Street_StreetNumber varchar(200) DEFAULT NULL,
+  Street_StreetPrefix varchar(200) DEFAULT NULL,
+  Street_StreetName varchar(200) DEFAULT NULL,
+  Street_StreetType varchar(200) DEFAULT NULL,
+  Street_StreetSuffix varchar(200) DEFAULT NULL,
+  Street_ApartmentType varchar(200) DEFAULT NULL,
+  Street_ApartmentNumberPrefix varchar(200) DEFAULT NULL,
+  Street_ApartmentNumber varchar(200) DEFAULT NULL,
+  Street_ApartmentNumberSuffix varchar(200) DEFAULT NULL,
+  City varchar(200) DEFAULT NULL,
+  StateProvince varchar(200) DEFAULT NULL,
+  Country varchar(200) DEFAULT NULL,
+  PostalCode varchar(200) DEFAULT NULL,
+  GridLocation_Latitude varchar(200) DEFAULT NULL,
+  GridLocation_Longitude varchar(200) DEFAULT NULL,
+  MapReference_Type varchar(200) DEFAULT NULL,
+  MapReference_XCoordinate varchar(200) DEFAULT NULL,
+  MapReference_YCoordinate varchar(200) DEFAULT NULL,
+  RadioContact varchar(200) DEFAULT NULL,
+  Community varchar(200) DEFAULT NULL,
+  LocalId varchar(200) DEFAULT NULL,
+  AddressGlobalUID varchar(200) DEFAULT NULL,
+  INDEX `Address_FQSubmissionEntityContact_IX` (`FQSubmission_EntityContact_Id`),
+  CONSTRAINT `Address_FQSubmissionEntityContact_FK` FOREIGN KEY (`FQSubmission_EntityContact_Id`) REFERENCES `FQSubmission_EntityContact` (`Id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+  
+create table FQSubmission_EntityContact_Address_StatisticalArea (
+  id MEDIUMINT AUTO_INCREMENT PRIMARY KEY,
+  FQSubmission_EntityContact_Address_Id MEDIUMINT NOT NULL,
+  spatialUnitType varchar(200) DEFAULT NULL,
+  statisticalArea varchar(200) DEFAULT NULL,
+  INDEX `StatArea_FQSubmissionEntityContactAddress_IX` (`FQSubmission_EntityContact_Address_Id`),
+  CONSTRAINT `StatArea_FQSubmissionEntityContactAddress_FK` FOREIGN KEY (`FQSubmission_EntityContact_Address_Id`) REFERENCES `FQSubmission_EntityContact_Address` (`Id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+create table FQReporting (
+  id MEDIUMINT AUTO_INCREMENT PRIMARY KEY,
+  FQSubmission_RefId varchar(36) NOT NULL,
+  FQRefId varchar(36) DEFAULT NULL,
+  EntityLevel varchar(200) DEFAULT NULL,
+  SchoolInfo_RefId varchar(36) DEFAULT NULL,
+  LocalId varchar(200) DEFAULT NULL,
+  StateProvinceId varchar(200) DEFAULT NULL,
+  CommonwealthId varchar(200) DEFAULT NULL,
+  AcaraId varchar(200) DEFAULT NULL,
+  EntityName varchar(200) DEFAULT NULL,
+  INDEX `FQReporting_FQSubmission_IX` (`FQSubmission_RefId`),
+  CONSTRAINT `FQReporting_FQSubmission_FK` FOREIGN KEY (`FQSubmission_RefId`) REFERENCES `FinancialQuestionnaireSubmission` (`RefId`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+create table FQReporting_EntityContact (
+  id MEDIUMINT AUTO_INCREMENT PRIMARY KEY,
+  FQReporting_Id MEDIUMINT NOT NULL,
+  PositionTitle varchar(200) DEFAULT NULL,
+  Role varchar(200) DEFAULT NULL,
+  RegistrationDetails varchar(200) DEFAULT NULL,
+  Qualifications varchar(200) DEFAULT NULL,
+  Email_Type varchar(200) DEFAULT NULL,
+  Email_Value varchar(200) DEFAULT NULL,
+  PhoneNumber_Type varchar(200) DEFAULT NULL,
+  PhoneNumber_Number varchar(200) DEFAULT NULL,
+  PhoneNumber_Extension varchar(200) DEFAULT NULL,
+  PhoneNumber_ListedStatus varchar(200) DEFAULT NULL,
+  PhoneNumber_Preference varchar(200) DEFAULT NULL,
+  INDEX `EntityContact_FQReporting_IX` (`FQReporting_Id`),
+  CONSTRAINT `EntityContact_FQReporting_FK` FOREIGN KEY (`FQReporting_Id`) REFERENCES `FQReporting` (`Id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 create table FQReporting_EntityContact_Name (
@@ -1619,7 +1858,9 @@ create table FQReporting_EntityContact_Name (
   PreferredFamilyNameFirst varchar(200) DEFAULT NULL,
   PreferredGivenName varchar(200) DEFAULT NULL,
   Suffix varchar(200) DEFAULT NULL,
-  FullName varchar(200) DEFAULT NULL
+  FullName varchar(200) DEFAULT NULL,
+  INDEX `Name_FQReportingEntityContact_IX` (`FQReporting_EntityContact_Id`),
+  CONSTRAINT `Name_FQReportingEntityContact_FK` FOREIGN KEY (`FQReporting_EntityContact_Id`) REFERENCES `FQReporting_EntityContact` (`Id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 create table FQReporting_EntityContact_Address (
@@ -1654,38 +1895,49 @@ create table FQReporting_EntityContact_Address (
   RadioContact varchar(200) DEFAULT NULL,
   Community varchar(200) DEFAULT NULL,
   LocalId varchar(200) DEFAULT NULL,
-  AddressGlobalUID varchar(200) DEFAULT NULL
+  AddressGlobalUID varchar(200) DEFAULT NULL,
+  INDEX `Address_FQReportingEntityContact_IX` (`FQReporting_EntityContact_Id`),
+  CONSTRAINT `Address_FQReportingEntityContact_FK` FOREIGN KEY (`FQReporting_EntityContact_Id`) REFERENCES `FQReporting_EntityContact` (`Id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
   
 create table FQReporting_EntityContact_Address_StatisticalArea (
   id MEDIUMINT AUTO_INCREMENT PRIMARY KEY,
   FQReporting_EntityContact_Address_Id MEDIUMINT NOT NULL,
   spatialUnitType varchar(200) DEFAULT NULL,
-  statisticalArea varchar(200) DEFAULT NULL
+  statisticalArea varchar(200) DEFAULT NULL,
+  INDEX `StatArea_FQReportingEntityContactAddress_IX` (`FQReporting_EntityContact_Address_Id`),
+  CONSTRAINT `StatArea_FQReportingEntityContactAddress_FK` FOREIGN KEY (`FQReporting_EntityContact_Address_Id`) REFERENCES `FQReporting_EntityContact_Address` (`Id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 create table FQReporting_ContextualQuestion (
   id MEDIUMINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
-  FQReporting_RefId varchar(36) NOT NULL,
+  FQReporting_Id MEDIUMINT NOT NULL,
   Context varchar(200) DEFAULT NULL,
-  Answer varchar(200) DEFAULT NULL
+  Answer varchar(200) DEFAULT NULL,
+  INDEX `ContextualQuestion_FQReporting_IX` (`FQReporting_Id`),
+  CONSTRAINT `ContextualQuestion_FQReporting_FK` FOREIGN KEY (`FQReporting_Id`) REFERENCES `FQReporting` (`Id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 create table FQReporting_FQItem (
   id MEDIUMINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
-  FQReporting_RefId varchar(36) NOT NULL,
+  FQReporting_Id MEDIUMINT NOT NULL,
   FQItemCode varchar(200) DEFAULT NULL,
   TuitionAmount varchar(200) DEFAULT NULL,
   BoardingAmount varchar(200) DEFAULT NULL,
   SystemAmount varchar(200) DEFAULT NULL,
   DioceseAmount varchar(200) DEFAULT NULL,
-  FQComment varchar(200) DEFAULT NULL
+  FQComments varchar(200) DEFAULT NULL,
+  INDEX `FQItem_FQReporting_IX` (`FQReporting_Id`),
+  CONSTRAINT `FQItem_FQReporting_FK` FOREIGN KEY (`FQReporting_Id`) REFERENCES `FQReporting` (`Id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-create table FQReporting_FQRule (
-  id MEDIUMINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
-  FQReporting_RefId varchar(36) NOT NULL,
-  FQRuleCode varchar(200) DEFAULT NULL,
-  FQRuleComment varchar(200) DEFAULT NULL
+CREATE TABLE FQReporting_AGRule (
+   Id MEDIUMINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+   FQReporting_Id MEDIUMINT NOT NULL,
+   AGRuleCode VARCHAR(200),
+   AGRuleComment VARCHAR(200),
+   AGRuleResponse VARCHAR(200),
+   AGRuleStatus VARCHAR(200),
+   INDEX `Rule_FQReporting_IX` (`FQReporting_Id`),
+   CONSTRAINT `Rule_FQReporting_FK` FOREIGN KEY (`FQReporting_Id`) REFERENCES `FQReporting` (`Id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-

--- a/schema/migrations/v2.7.0-v2.8.0.sql
+++ b/schema/migrations/v2.7.0-v2.8.0.sql
@@ -29,6 +29,9 @@ ALTER TABLE StudentSchoolEnrollment DROP INDEX StudentPersonal_RefId;
 CREATE UNIQUE INDEX StudentSchoolEnrollment_RefId_IX ON StudentSchoolEnrollment (RefId);
 CREATE INDEX StudentSchoolEnrollment_StudentPersonal_RefId_IX ON StudentSchoolEnrollment (StudentPersonal_RefId);
 CREATE INDEX StudentSchoolEnrollment_SchoolInfo_RefId_IX ON StudentSchoolEnrollment (SchoolInfo_RefId);
+ALTER TABLE PersonPicture MODIFY COLUMN RefId varchar(36) NOT NULL;
+ALTER TABLE PersonPicture ADD CONSTRAINT PersonPicture_PK PRIMARY KEY (RefId);
+CREATE UNIQUE INDEX PersonPicture_RefId_IX ON PersonPicture (RefId);
 
 ALTER TABLE StudentPersonal_OtherId ADD id INT PRIMARY KEY NOT NULL AUTO_INCREMENT FIRST;
 
@@ -66,4 +69,15 @@ CREATE TABLE StudentSchoolEnrollment_StudentSubjectChoice (
    UNIQUE INDEX SSE_StudentSubjectChoice_PKX (ID),
    INDEX SSE_StudentSubjectChoice_IX (StudentSchoolEnrollment_RefId),
    CONSTRAINT SSE_StudentSubjectChoice_FK FOREIGN KEY (StudentSchoolEnrollment_RefId) REFERENCES StudentSchoolEnrollment (RefId)
+) Engine=InnoDB DEFAULT Charset=utf8;
+
+CREATE TABLE PersonPicture_PublishingPermission (
+   ID INT(11) NOT NULL AUTO_INCREMENT,
+   PersonPicture_RefId VARCHAR(36) NOT NULL,
+   PermissionCategory VARCHAR(200),
+   PermissionValue VARCHAR(200),
+   PRIMARY KEY (id),
+   UNIQUE INDEX PP_PublishingPermission_PKX (ID),
+   INDEX PP_PublishingPermission_IX (PersonPicture_RefId),
+   CONSTRAINT PP_PublishingPermission_FK FOREIGN KEY (PersonPicture_RefId) REFERENCES PersonPicture (RefId)
 ) Engine=InnoDB DEFAULT Charset=utf8;

--- a/schema/migrations/v2.7.0-v2.8.0.sql
+++ b/schema/migrations/v2.7.0-v2.8.0.sql
@@ -35,7 +35,6 @@ ALTER TABLE StudentSchoolEnrollment DROP KEY RefId;
 ALTER TABLE StudentSchoolEnrollment ADD CONSTRAINT StudentSchoolEnrollment_PK PRIMARY KEY (RefId);
 ALTER TABLE StudentSchoolEnrollment DROP INDEX SchoolInfo_RefId;
 ALTER TABLE StudentSchoolEnrollment DROP INDEX StudentPersonal_RefId;
-CREATE UNIQUE INDEX StudentSchoolEnrollment_RefId_IX ON StudentSchoolEnrollment (RefId);
 CREATE INDEX StudentSchoolEnrollment_StudentPersonal_RefId_IX ON StudentSchoolEnrollment (StudentPersonal_RefId);
 CREATE INDEX StudentSchoolEnrollment_SchoolInfo_RefId_IX ON StudentSchoolEnrollment (SchoolInfo_RefId);
 
@@ -45,7 +44,6 @@ CREATE TABLE StudentSchoolEnrollment_PublishingPermission (
    PermissionCategory VARCHAR(200),
    PermissionValue VARCHAR(200),
    PRIMARY KEY (id),
-   UNIQUE INDEX SSE_PublishingPermission_PKX (ID),
    INDEX SSE_PublishingPermission_IX (StudentSchoolEnrollment_RefId),
    CONSTRAINT SSE_PublishingPermission_FK FOREIGN KEY (StudentSchoolEnrollment_RefId) REFERENCES StudentSchoolEnrollment (RefId)
 ) Engine=InnoDB DEFAULT Charset=utf8;
@@ -57,7 +55,6 @@ CREATE TABLE StudentSchoolEnrollment_StudentGroup (
    GroupLocalId VARCHAR(200),
    GroupDescription VARCHAR(2000),
    PRIMARY KEY (id),
-   UNIQUE INDEX SSE_StudentGroup_PKX (ID),
    INDEX SSE_StudentGroup_IX (StudentSchoolEnrollment_RefId),
    CONSTRAINT SSE_StudentGroup_FK FOREIGN KEY (StudentSchoolEnrollment_RefId) REFERENCES StudentSchoolEnrollment (RefId)
 ) Engine=InnoDB DEFAULT Charset=utf8;
@@ -70,7 +67,6 @@ CREATE TABLE StudentSchoolEnrollment_StudentSubjectChoice (
    StudyDescription VARCHAR(200),
    OtherSchoolLocalId VARCHAR(200),
    PRIMARY KEY (id),
-   UNIQUE INDEX SSE_StudentSubjectChoice_PKX (ID),
    INDEX SSE_StudentSubjectChoice_IX (StudentSchoolEnrollment_RefId),
    CONSTRAINT SSE_StudentSubjectChoice_FK FOREIGN KEY (StudentSchoolEnrollment_RefId) REFERENCES StudentSchoolEnrollment (RefId)
 ) Engine=InnoDB DEFAULT Charset=utf8;
@@ -81,7 +77,6 @@ CREATE TABLE StudentSchoolEnrollment_StudentSubjectChoice (
  */
 ALTER TABLE PersonPicture MODIFY COLUMN RefId varchar(36) NOT NULL;
 ALTER TABLE PersonPicture ADD CONSTRAINT PersonPicture_PK PRIMARY KEY (RefId);
-CREATE UNIQUE INDEX PersonPicture_RefId_IX ON PersonPicture (RefId);
 
 CREATE TABLE PersonPicture_PublishingPermission (
    ID INT(11) NOT NULL AUTO_INCREMENT,
@@ -97,6 +92,8 @@ CREATE TABLE PersonPicture_PublishingPermission (
 /**
  * Changes to StaffAssignment
  */
+ALTER TABLE StaffAssignment MODIFY COLUMN RefId varchar(36) NOT NULL;
+ALTER TABLE StaffAssignment ADD CONSTRAINT StaffAssignment_PK PRIMARY KEY (RefId); 
 ALTER TABLE StaffAssignment ADD JobFTE VARCHAR(20) NULL;
 ALTER TABLE StaffAssignment ADD EmploymentStatus VARCHAR(20) NULL;
 ALTER TABLE StaffAssignment ADD CasualReliefTeacher VARCHAR(20) NULL;
@@ -127,7 +124,6 @@ CREATE TABLE StaffAssignment_StaffSubject (
    SubjectLocalId VARCHAR(200),
    TimeTableSubject_RefId VARCHAR(36),
    PRIMARY KEY (id),
-   UNIQUE INDEX SA_StaffSubject_PKX (ID),
    INDEX SA_StaffSubject_IX (StaffAssignment_RefId),
    CONSTRAINT SA_StaffSubject_FK FOREIGN KEY (StaffAssignment_RefId) REFERENCES StaffAssignment (RefId)  
 ) Engine=InnoDB DEFAULT Charset=utf8;
@@ -135,6 +131,7 @@ CREATE TABLE StaffAssignment_StaffSubject (
 /** 
  * Changes to StudentPersonal
  */
+ALTER TABLE StudentPersonal ADD CONSTRAINT StudentPersonal_PK PRIMARY KEY (RefId);
 ALTER TABLE StudentPersonal ADD ESLSupport VARCHAR(20) NULL;
 
 /**

--- a/schema/migrations/v2.7.0-v2.8.0.sql
+++ b/schema/migrations/v2.7.0-v2.8.0.sql
@@ -416,3 +416,10 @@ CREATE TABLE FQReporting_AGRule (
 ALTER TABLE VendorInfo add ContactInfo_Qualifications VARCHAR(200) NULL;
 ALTER TABLE VendorInfo add ContactInfo_RegistrationDetails VARCHAR(200) NULL;
 
+/**
+ * Demographics changes
+ */
+ALTER TABLE StudentPersonal add InterpreterRequired VARCHAR(20) null;
+ALTER TABLE StaffPersonal add InterpreterRequired VARCHAR(20) null;
+ALTER TABLE StudentContactPersonal add InterpreterRequired VARCHAR(20) null;
+

--- a/schema/migrations/v2.7.0-v2.8.0.sql
+++ b/schema/migrations/v2.7.0-v2.8.0.sql
@@ -1,3 +1,12 @@
+/*
+ * Simplify link between StudentPersonal_OtherId and Student
+ */
+ALTER TABLE StudentPersonal_OtherId ADD id INT PRIMARY KEY NOT NULL AUTO_INCREMENT FIRST;
+ALTER TABLE StudentAttendanceTimeList_AttendanceTime_OtherCode ADD id INT PRIMARY KEY NOT NULL AUTO_INCREMENT FIRST;
+
+/*
+ * Changes to StudentSchoolEnrollment
+ */
 ALTER TABLE StudentSchoolEnrollment ADD LocalId VARCHAR(200) NULL;
 ALTER TABLE StudentSchoolEnrollment ADD EntryType VARCHAR(200) NULL;
 ALTER TABLE StudentSchoolEnrollment ADD Homeroom_RefId VARCHAR(36) NULL;
@@ -7,13 +16,13 @@ ALTER TABLE StudentSchoolEnrollment ADD Homegroup VARCHAR(200) NULL;
 ALTER TABLE StudentSchoolEnrollment ADD AcaraSchoolId VARCHAR(200) NULL;
 ALTER TABLE StudentSchoolEnrollment ADD TestLevel VARCHAR(200) NULL;
 ALTER TABLE StudentSchoolEnrollment ADD House VARCHAR(200) NULL;
-ALTER TABLE StudentSchoolEnrollment ADD IndividualLearningPlan VARCHAR(10) NULL;
+ALTER TABLE StudentSchoolEnrollment ADD IndividualLearningPlan VARCHAR(20) NULL;
 ALTER TABLE StudentSchoolEnrollment ADD Calendar_RefId VARCHAR(36) NULL;
-ALTER TABLE StudentSchoolEnrollment ADD ExitStatus VARCHAR(10) NULL;
-ALTER TABLE StudentSchoolEnrollment ADD ExitType VARCHAR(10) NULL;
-ALTER TABLE StudentSchoolEnrollment ADD FTPTStatus VARCHAR(10) NULL;
-ALTER TABLE StudentSchoolEnrollment ADD FFPOS VARCHAR(10) NULL;
-ALTER TABLE StudentSchoolEnrollment ADD CatchmentStatus VARCHAR(10) NULL;
+ALTER TABLE StudentSchoolEnrollment ADD ExitStatus VARCHAR(20) NULL;
+ALTER TABLE StudentSchoolEnrollment ADD ExitType VARCHAR(20) NULL;
+ALTER TABLE StudentSchoolEnrollment ADD FTPTStatus VARCHAR(20) NULL;
+ALTER TABLE StudentSchoolEnrollment ADD FFPOS VARCHAR(20) NULL;
+ALTER TABLE StudentSchoolEnrollment ADD CatchmentStatus VARCHAR(20) NULL;
 ALTER TABLE StudentSchoolEnrollment ADD PreviousSchool VARCHAR(200) NULL;
 ALTER TABLE StudentSchoolEnrollment ADD PreviousSchoolName VARCHAR(200) NULL;
 ALTER TABLE StudentSchoolEnrollment ADD DestinationSchool VARCHAR(200) NULL;
@@ -29,11 +38,6 @@ ALTER TABLE StudentSchoolEnrollment DROP INDEX StudentPersonal_RefId;
 CREATE UNIQUE INDEX StudentSchoolEnrollment_RefId_IX ON StudentSchoolEnrollment (RefId);
 CREATE INDEX StudentSchoolEnrollment_StudentPersonal_RefId_IX ON StudentSchoolEnrollment (StudentPersonal_RefId);
 CREATE INDEX StudentSchoolEnrollment_SchoolInfo_RefId_IX ON StudentSchoolEnrollment (SchoolInfo_RefId);
-ALTER TABLE PersonPicture MODIFY COLUMN RefId varchar(36) NOT NULL;
-ALTER TABLE PersonPicture ADD CONSTRAINT PersonPicture_PK PRIMARY KEY (RefId);
-CREATE UNIQUE INDEX PersonPicture_RefId_IX ON PersonPicture (RefId);
-
-ALTER TABLE StudentPersonal_OtherId ADD id INT PRIMARY KEY NOT NULL AUTO_INCREMENT FIRST;
 
 CREATE TABLE StudentSchoolEnrollment_PublishingPermission (
    ID INT(11) NOT NULL AUTO_INCREMENT,
@@ -71,6 +75,14 @@ CREATE TABLE StudentSchoolEnrollment_StudentSubjectChoice (
    CONSTRAINT SSE_StudentSubjectChoice_FK FOREIGN KEY (StudentSchoolEnrollment_RefId) REFERENCES StudentSchoolEnrollment (RefId)
 ) Engine=InnoDB DEFAULT Charset=utf8;
 
+
+/**
+ * Changes to PersonPicture
+ */
+ALTER TABLE PersonPicture MODIFY COLUMN RefId varchar(36) NOT NULL;
+ALTER TABLE PersonPicture ADD CONSTRAINT PersonPicture_PK PRIMARY KEY (RefId);
+CREATE UNIQUE INDEX PersonPicture_RefId_IX ON PersonPicture (RefId);
+
 CREATE TABLE PersonPicture_PublishingPermission (
    ID INT(11) NOT NULL AUTO_INCREMENT,
    PersonPicture_RefId VARCHAR(36) NOT NULL,
@@ -81,3 +93,95 @@ CREATE TABLE PersonPicture_PublishingPermission (
    INDEX PP_PublishingPermission_IX (PersonPicture_RefId),
    CONSTRAINT PP_PublishingPermission_FK FOREIGN KEY (PersonPicture_RefId) REFERENCES PersonPicture (RefId)
 ) Engine=InnoDB DEFAULT Charset=utf8;
+
+/**
+ * Changes to StaffAssignment
+ */
+ALTER TABLE StaffAssignment ADD JobFTE VARCHAR(20) NULL;
+ALTER TABLE StaffAssignment ADD EmploymentStatus VARCHAR(20) NULL;
+ALTER TABLE StaffAssignment ADD CasualReliefTeacher VARCHAR(20) NULL;
+ALTER TABLE StaffAssignment ADD Homegroup VARCHAR(200) NULL;
+ALTER TABLE StaffAssignment ADD House VARCHAR(200) NULL;
+ALTER TABLE StaffAssignment ADD PreviousSchoolName VARCHAR(200) NULL;
+
+CREATE TABLE StaffAssignment_YearLevel (
+   StaffAssignment_RefId VARCHAR(36) NOT NULL,
+   YearLevel VARCHAR(20) NOT NULL,
+   PRIMARY KEY (StaffAssignment_RefId, YearLevel),
+   INDEX SA_YearLevel_FKX (StaffAssignment_RefId),
+   CONSTRAINT SA_YearLevel_FK FOREIGN KEY (StaffAssignment_RefId) REFERENCES StaffAssignment (RefId)
+) Engine=InnoDB DEFAULT Charset=utf8;
+
+CREATE TABLE StaffAssignment_CalendarSummary (
+   StaffAssignment_RefId VARCHAR(36) NOT NULL,
+   CalendarSummary_RefId VARCHAR(36) NOT NULL,
+   PRIMARY KEY (StaffAssignment_RefId, CalendarSummary_RefId),
+   INDEX SA_CalendarSummary_FKX (StaffAssignment_RefId),
+   CONSTRAINT SA_CalendarSummary_FK FOREIGN KEY (StaffAssignment_RefId) REFERENCES StaffAssignment (RefId)
+) Engine=InnoDB DEFAULT Charset=utf8;
+
+CREATE TABLE StaffAssignment_StaffSubject (
+   ID INT(11) NOT NULL AUTO_INCREMENT,
+   StaffAssignment_RefId VARCHAR(36) NOT NULL,
+   PreferenceNumber VARCHAR(200),
+   SubjectLocalId VARCHAR(200),
+   TimeTableSubject_RefId VARCHAR(36),
+   PRIMARY KEY (id),
+   UNIQUE INDEX SA_StaffSubject_PKX (ID),
+   INDEX SA_StaffSubject_IX (StaffAssignment_RefId),
+   CONSTRAINT SA_StaffSubject_FK FOREIGN KEY (StaffAssignment_RefId) REFERENCES StaffAssignment (RefId)  
+) Engine=InnoDB DEFAULT Charset=utf8;
+
+/** 
+ * Changes to StudentPersonal
+ */
+ALTER TABLE StudentPersonal ADD ESLSupport VARCHAR(20) NULL;
+
+/**
+ * Changes for FQ Reporting
+ */
+DROP TABLE FQReporting_FQRule;
+DROP TABLE FQReporting_FQItem;
+DROP TABLE FQReporting_ContextualQuestion;
+DROP TABLE FQReporting_EntityContact_Address_StatisticalArea;
+DROP TABLE FQReporting_EntityContact_Address;
+DROP TABLE FQReporting_EntityContact_Name;
+DROP TABLE FQReporting_EntityContact;
+DROP TABLE FQReporting;
+
+CREATE TABLE AGStatusReport (
+   RefId VARCHAR(36) NOT NULL PRIMARY KEY,
+   ReportingAuthority VARCHAR(200),
+   ReportingAuthoritySystem VARCHAR(200),
+   ReportingAuthorityCommonwealthId VARCHAR(200),
+   SubmittedBy VARCHAR(200),
+   SubmissionTimestamp VARCHAR(200),
+   AGCollection VARCHAR(200),
+   CollectionYear VARCHAR(200)
+); 
+
+CREATE TABLE AGStatusReport_ReportingObjectResponse (
+   Id MEDIUMINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+   AGStatusReport_RefId VARCHAR(36) NOT NULL,
+   SubmittedRefId VARCHAR(36),
+   SIFRefId VARCHAR(36),
+   HTTPStatusCode VARCHAR(200),
+   ErrorText VARCHAR(200),
+   CommonwealthId VARCHAR(200),
+   EntityName VARCHAR(200),
+   AGSubmissionStatusCode VARCHAR(200),
+   INDEX `ReportingObjectResponse_AGStatusReport_IX` (`AGStatusReport_RefId`),
+   CONSTRAINT `ReportingObjectResponse_AGStatusReport_FK` FOREIGN KEY (`AGStatusReport_RefId`) REFERENCES `AGStatusReport` (`RefId`)
+);
+
+CREATE TABLE AGStatusReport_AGRule (
+   Id MEDIUMINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+   ReportingObjectResponse_Id MEDIUMINT NOT NULL,
+   AGRuleCode VARCHAR(200),
+   AGRuleComment VARCHAR(200),
+   AGRuleResponse VARCHAR(200),
+   AGRuleStatus VARCHAR(200),
+   INDEX `Rule_ReportingObjectResponse_IX` (`ReportingObjectResponse_Id`),
+   CONSTRAINT `Rule_ReportingObjectResponse_FK` FOREIGN KEY (`ReportingObjectResponse_Id`) REFERENCES `AGStatusReport_ReportingObjectResponse` (`Id`)
+);
+

--- a/schema/migrations/v2.7.0-v2.8.0.sql
+++ b/schema/migrations/v2.7.0-v2.8.0.sql
@@ -409,3 +409,10 @@ CREATE TABLE FQReporting_AGRule (
    INDEX `Rule_FQReporting_IX` (`FQReporting_Id`),
    CONSTRAINT `Rule_FQReporting_FK` FOREIGN KEY (`FQReporting_Id`) REFERENCES `FQReporting` (`Id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+/**
+ * ContactInfo changes
+ */
+ALTER TABLE VendorInfo add ContactInfo_Qualifications VARCHAR(200) NULL;
+ALTER TABLE VendorInfo add ContactInfo_RegistrationDetails VARCHAR(200) NULL;
+

--- a/schema/migrations/v2.7.0-v2.8.0.sql
+++ b/schema/migrations/v2.7.0-v2.8.0.sql
@@ -30,6 +30,8 @@ CREATE UNIQUE INDEX StudentSchoolEnrollment_RefId_IX ON StudentSchoolEnrollment 
 CREATE INDEX StudentSchoolEnrollment_StudentPersonal_RefId_IX ON StudentSchoolEnrollment (StudentPersonal_RefId);
 CREATE INDEX StudentSchoolEnrollment_SchoolInfo_RefId_IX ON StudentSchoolEnrollment (SchoolInfo_RefId);
 
+ALTER TABLE StudentPersonal_OtherId ADD id INT PRIMARY KEY NOT NULL AUTO_INCREMENT FIRST;
+
 CREATE TABLE StudentSchoolEnrollment_PublishingPermission (
    ID INT(11) NOT NULL AUTO_INCREMENT,
    StudentSchoolEnrollment_RefId VARCHAR(36) NOT NULL,
@@ -56,7 +58,7 @@ CREATE TABLE StudentSchoolEnrollment_StudentGroup (
 CREATE TABLE StudentSchoolEnrollment_StudentSubjectChoice (
    ID INT(11) NOT NULL AUTO_INCREMENT,
    StudentSchoolEnrollment_RefId VARCHAR(36) NOT NULL,
-   PerferenceNumber VARCHAR(200),
+   PreferenceNumber VARCHAR(200),
    SubjectLocalId VARCHAR(200),
    StudyDescription VARCHAR(200),
    OtherSchoolLocalId VARCHAR(200),

--- a/schema/migrations/v2.7.0-v2.8.0.sql
+++ b/schema/migrations/v2.7.0-v2.8.0.sql
@@ -1,0 +1,67 @@
+ALTER TABLE StudentSchoolEnrollment ADD LocalId VARCHAR(200) NULL;
+ALTER TABLE StudentSchoolEnrollment ADD EntryType VARCHAR(200) NULL;
+ALTER TABLE StudentSchoolEnrollment ADD Homeroom_RefId VARCHAR(36) NULL;
+ALTER TABLE StudentSchoolEnrollment ADD Advisor_RefId VARCHAR(36) NULL;
+ALTER TABLE StudentSchoolEnrollment ADD Counselor_RefId VARCHAR(36) NULL;
+ALTER TABLE StudentSchoolEnrollment ADD Homegroup VARCHAR(200) NULL;
+ALTER TABLE StudentSchoolEnrollment ADD AcaraSchoolId VARCHAR(200) NULL;
+ALTER TABLE StudentSchoolEnrollment ADD TestLevel VARCHAR(200) NULL;
+ALTER TABLE StudentSchoolEnrollment ADD House VARCHAR(200) NULL;
+ALTER TABLE StudentSchoolEnrollment ADD IndividualLearningPlan VARCHAR(10) NULL;
+ALTER TABLE StudentSchoolEnrollment ADD Calendar_RefId VARCHAR(36) NULL;
+ALTER TABLE StudentSchoolEnrollment ADD ExitStatus VARCHAR(10) NULL;
+ALTER TABLE StudentSchoolEnrollment ADD ExitType VARCHAR(10) NULL;
+ALTER TABLE StudentSchoolEnrollment ADD FTPTStatus VARCHAR(10) NULL;
+ALTER TABLE StudentSchoolEnrollment ADD FFPOS VARCHAR(10) NULL;
+ALTER TABLE StudentSchoolEnrollment ADD CatchmentStatus VARCHAR(10) NULL;
+ALTER TABLE StudentSchoolEnrollment ADD PreviousSchool VARCHAR(200) NULL;
+ALTER TABLE StudentSchoolEnrollment ADD PreviousSchoolName VARCHAR(200) NULL;
+ALTER TABLE StudentSchoolEnrollment ADD DestinationSchool VARCHAR(200) NULL;
+ALTER TABLE StudentSchoolEnrollment ADD DestinationSchoolName VARCHAR(200) NULL;
+ALTER TABLE StudentSchoolEnrollment ADD StartedAtSchoolDate VARCHAR(25) NULL;
+ALTER TABLE StudentSchoolEnrollment DROP FOREIGN KEY StudentSchoolEnrollment_ibfk_1;
+ALTER TABLE StudentSchoolEnrollment DROP FOREIGN KEY StudentSchoolEnrollment_ibfk_2;
+ALTER TABLE StudentSchoolEnrollment MODIFY COLUMN RefId varchar(36) NOT NULL;
+ALTER TABLE StudentSchoolEnrollment DROP KEY RefId;
+ALTER TABLE StudentSchoolEnrollment ADD CONSTRAINT StudentSchoolEnrollment_PK PRIMARY KEY (RefId);
+ALTER TABLE StudentSchoolEnrollment DROP INDEX SchoolInfo_RefId;
+ALTER TABLE StudentSchoolEnrollment DROP INDEX StudentPersonal_RefId;
+CREATE UNIQUE INDEX StudentSchoolEnrollment_RefId_IX ON StudentSchoolEnrollment (RefId);
+CREATE INDEX StudentSchoolEnrollment_StudentPersonal_RefId_IX ON StudentSchoolEnrollment (StudentPersonal_RefId);
+CREATE INDEX StudentSchoolEnrollment_SchoolInfo_RefId_IX ON StudentSchoolEnrollment (SchoolInfo_RefId);
+
+CREATE TABLE StudentSchoolEnrollment_PublishingPermission (
+   ID INT(11) NOT NULL AUTO_INCREMENT,
+   StudentSchoolEnrollment_RefId VARCHAR(36) NOT NULL,
+   PermissionCategory VARCHAR(200),
+   PermissionValue VARCHAR(200),
+   PRIMARY KEY (id),
+   UNIQUE INDEX SSE_PublishingPermission_PKX (ID),
+   INDEX SSE_PublishingPermission_IX (StudentSchoolEnrollment_RefId),
+   CONSTRAINT SSE_PublishingPermission_FK FOREIGN KEY (StudentSchoolEnrollment_RefId) REFERENCES StudentSchoolEnrollment (RefId)
+) Engine=InnoDB DEFAULT Charset=utf8;
+
+CREATE TABLE StudentSchoolEnrollment_StudentGroup (
+   ID INT(11) NOT NULL AUTO_INCREMENT,
+   StudentSchoolEnrollment_RefId VARCHAR(36) NOT NULL,
+   GroupCategory VARCHAR(200),
+   GroupLocalId VARCHAR(200),
+   GroupDescription VARCHAR(2000),
+   PRIMARY KEY (id),
+   UNIQUE INDEX SSE_StudentGroup_PKX (ID),
+   INDEX SSE_StudentGroup_IX (StudentSchoolEnrollment_RefId),
+   CONSTRAINT SSE_StudentGroup_FK FOREIGN KEY (StudentSchoolEnrollment_RefId) REFERENCES StudentSchoolEnrollment (RefId)
+) Engine=InnoDB DEFAULT Charset=utf8;
+
+CREATE TABLE StudentSchoolEnrollment_StudentSubjectChoice (
+   ID INT(11) NOT NULL AUTO_INCREMENT,
+   StudentSchoolEnrollment_RefId VARCHAR(36) NOT NULL,
+   PerferenceNumber VARCHAR(200),
+   SubjectLocalId VARCHAR(200),
+   StudyDescription VARCHAR(200),
+   OtherSchoolLocalId VARCHAR(200),
+   PRIMARY KEY (id),
+   UNIQUE INDEX SSE_StudentSubjectChoice_PKX (ID),
+   INDEX SSE_StudentSubjectChoice_IX (StudentSchoolEnrollment_RefId),
+   CONSTRAINT SSE_StudentSubjectChoice_FK FOREIGN KEY (StudentSchoolEnrollment_RefId) REFERENCES StudentSchoolEnrollment (RefId)
+) Engine=InnoDB DEFAULT Charset=utf8;

--- a/schema/migrations/v2.7.0-v2.8.0.sql
+++ b/schema/migrations/v2.7.0-v2.8.0.sql
@@ -158,7 +158,7 @@ CREATE TABLE AGStatusReport (
    SubmissionTimestamp VARCHAR(200),
    AGCollection VARCHAR(200),
    CollectionYear VARCHAR(200)
-); 
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE AGStatusReport_ReportingObjectResponse (
    Id MEDIUMINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
@@ -172,7 +172,7 @@ CREATE TABLE AGStatusReport_ReportingObjectResponse (
    AGSubmissionStatusCode VARCHAR(200),
    INDEX `ReportingObjectResponse_AGStatusReport_IX` (`AGStatusReport_RefId`),
    CONSTRAINT `ReportingObjectResponse_AGStatusReport_FK` FOREIGN KEY (`AGStatusReport_RefId`) REFERENCES `AGStatusReport` (`RefId`)
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE AGStatusReport_AGRule (
    Id MEDIUMINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
@@ -183,5 +183,229 @@ CREATE TABLE AGStatusReport_AGRule (
    AGRuleStatus VARCHAR(200),
    INDEX `Rule_ReportingObjectResponse_IX` (`ReportingObjectResponse_Id`),
    CONSTRAINT `Rule_ReportingObjectResponse_FK` FOREIGN KEY (`ReportingObjectResponse_Id`) REFERENCES `AGStatusReport_ReportingObjectResponse` (`Id`)
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+create table FinancialQuestionnaireSubmission (
+  RefId varchar(36) NOT NULL,
+  FQYear varchar(200) DEFAULT NULL,
+  ReportingAuthority varchar(200) DEFAULT NULL,
+  ReportingAuthoritySystem varchar(200) DEFAULT NULL,
+  ReportingAuthorityCommonwealthId varchar(200) DEFAULT NULL,
+  SystemSubmission varchar(200) DEFAULT NULL,
+  SoftwareVendorInfo_SoftwareProduct varchar(200) DEFAULT NULL,
+  SoftwareVendorInfo_SoftwareVersion varchar(200) DEFAULT NULL,
+  FQReportComments varchar(200) DEFAULT NULL,
+  PRIMARY KEY (RefId)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+create table FQSubmission_EntityContact (
+  id MEDIUMINT AUTO_INCREMENT PRIMARY KEY,
+  FQSubmission_RefId varchar(36) NOT NULL,
+  PositionTitle varchar(200) DEFAULT NULL,
+  Role varchar(200) DEFAULT NULL,
+  RegistrationDetails varchar(200) DEFAULT NULL,
+  Qualifications varchar(200) DEFAULT NULL,
+  Email_Type varchar(200) DEFAULT NULL,
+  Email_Value varchar(200) DEFAULT NULL,
+  PhoneNumber_Type varchar(200) DEFAULT NULL,
+  PhoneNumber_Number varchar(200) DEFAULT NULL,
+  PhoneNumber_Extension varchar(200) DEFAULT NULL,
+  PhoneNumber_ListedStatus varchar(200) DEFAULT NULL,
+  PhoneNumber_Preference varchar(200) DEFAULT NULL,
+  INDEX `EntityContact_FQSubmission_IX` (`FQSubmission_RefId`),
+  CONSTRAINT `EntityContact_FQSubmission_FK` FOREIGN KEY (`FQSubmission_RefId`) REFERENCES `FinancialQuestionnaireSubmission` (`RefId`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+create table FQSubmission_EntityContact_Name (
+  id MEDIUMINT AUTO_INCREMENT PRIMARY KEY,
+  FQSubmission_EntityContact_Id MEDIUMINT NOT NULL,
+  NameType varchar(200) DEFAULT NULL,
+  Title varchar(200) DEFAULT NULL,
+  FamilyName varchar(200) DEFAULT NULL,
+  GivenName varchar(200) DEFAULT NULL,
+  MiddleName varchar(200) DEFAULT NULL,
+  FamilyNameFirst varchar(200) DEFAULT NULL,
+  PreferredFamilyName varchar(200) DEFAULT NULL,
+  PreferredFamilyNameFirst varchar(200) DEFAULT NULL,
+  PreferredGivenName varchar(200) DEFAULT NULL,
+  Suffix varchar(200) DEFAULT NULL,
+  FullName varchar(200) DEFAULT NULL,
+  INDEX `Name_FQSubmissionEntityContact_IX` (`FQSubmission_EntityContact_Id`),
+  CONSTRAINT `Name_FQSubmissionEntityContact_FK` FOREIGN KEY (`FQSubmission_EntityContact_Id`) REFERENCES `FQSubmission_EntityContact` (`Id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+create table FQSubmission_EntityContact_Address (
+  id MEDIUMINT AUTO_INCREMENT PRIMARY KEY,
+  FQSubmission_EntityContact_Id MEDIUMINT NOT NULL,
+  AddressType varchar(200) DEFAULT NULL,
+  AddressRole varchar(200) DEFAULT NULL,
+  EffectiveFromDate varchar(200) DEFAULT NULL,
+  EffectiveToDate varchar(200) DEFAULT NULL,
+  Street_Line1 varchar(200) DEFAULT NULL,
+  Street_Line2 varchar(200) DEFAULT NULL,
+  Street_Line3 varchar(200) DEFAULT NULL,
+  Street_Complex varchar(200) DEFAULT NULL,
+  Street_StreetNumber varchar(200) DEFAULT NULL,
+  Street_StreetPrefix varchar(200) DEFAULT NULL,
+  Street_StreetName varchar(200) DEFAULT NULL,
+  Street_StreetType varchar(200) DEFAULT NULL,
+  Street_StreetSuffix varchar(200) DEFAULT NULL,
+  Street_ApartmentType varchar(200) DEFAULT NULL,
+  Street_ApartmentNumberPrefix varchar(200) DEFAULT NULL,
+  Street_ApartmentNumber varchar(200) DEFAULT NULL,
+  Street_ApartmentNumberSuffix varchar(200) DEFAULT NULL,
+  City varchar(200) DEFAULT NULL,
+  StateProvince varchar(200) DEFAULT NULL,
+  Country varchar(200) DEFAULT NULL,
+  PostalCode varchar(200) DEFAULT NULL,
+  GridLocation_Latitude varchar(200) DEFAULT NULL,
+  GridLocation_Longitude varchar(200) DEFAULT NULL,
+  MapReference_Type varchar(200) DEFAULT NULL,
+  MapReference_XCoordinate varchar(200) DEFAULT NULL,
+  MapReference_YCoordinate varchar(200) DEFAULT NULL,
+  RadioContact varchar(200) DEFAULT NULL,
+  Community varchar(200) DEFAULT NULL,
+  LocalId varchar(200) DEFAULT NULL,
+  AddressGlobalUID varchar(200) DEFAULT NULL,
+  INDEX `Address_FQSubmissionEntityContact_IX` (`FQSubmission_EntityContact_Id`),
+  CONSTRAINT `Address_FQSubmissionEntityContact_FK` FOREIGN KEY (`FQSubmission_EntityContact_Id`) REFERENCES `FQSubmission_EntityContact` (`Id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+  
+create table FQSubmission_EntityContact_Address_StatisticalArea (
+  id MEDIUMINT AUTO_INCREMENT PRIMARY KEY,
+  FQSubmission_EntityContact_Address_Id MEDIUMINT NOT NULL,
+  spatialUnitType varchar(200) DEFAULT NULL,
+  statisticalArea varchar(200) DEFAULT NULL,
+  INDEX `StatArea_FQSubmissionEntityContactAddress_IX` (`FQSubmission_EntityContact_Address_Id`),
+  CONSTRAINT `StatArea_FQSubmissionEntityContactAddress_FK` FOREIGN KEY (`FQSubmission_EntityContact_Address_Id`) REFERENCES `FQSubmission_EntityContact_Address` (`Id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+create table FQReporting (
+  id MEDIUMINT AUTO_INCREMENT PRIMARY KEY,
+  FQSubmission_RefId varchar(36) NOT NULL,
+  FQRefId varchar(36) DEFAULT NULL,
+  EntityLevel varchar(200) DEFAULT NULL,
+  SchoolInfo_RefId varchar(36) DEFAULT NULL,
+  LocalId varchar(200) DEFAULT NULL,
+  StateProvinceId varchar(200) DEFAULT NULL,
+  CommonwealthId varchar(200) DEFAULT NULL,
+  AcaraId varchar(200) DEFAULT NULL,
+  EntityName varchar(200) DEFAULT NULL,
+  INDEX `FQReporting_FQSubmission_IX` (`FQSubmission_RefId`),
+  CONSTRAINT `FQReporting_FQSubmission_FK` FOREIGN KEY (`FQSubmission_RefId`) REFERENCES `FinancialQuestionnaireSubmission` (`RefId`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+create table FQReporting_EntityContact (
+  id MEDIUMINT AUTO_INCREMENT PRIMARY KEY,
+  FQReporting_Id MEDIUMINT NOT NULL,
+  PositionTitle varchar(200) DEFAULT NULL,
+  Role varchar(200) DEFAULT NULL,
+  RegistrationDetails varchar(200) DEFAULT NULL,
+  Qualifications varchar(200) DEFAULT NULL,
+  Email_Type varchar(200) DEFAULT NULL,
+  Email_Value varchar(200) DEFAULT NULL,
+  PhoneNumber_Type varchar(200) DEFAULT NULL,
+  PhoneNumber_Number varchar(200) DEFAULT NULL,
+  PhoneNumber_Extension varchar(200) DEFAULT NULL,
+  PhoneNumber_ListedStatus varchar(200) DEFAULT NULL,
+  PhoneNumber_Preference varchar(200) DEFAULT NULL,
+  INDEX `EntityContact_FQReporting_IX` (`FQReporting_Id`),
+  CONSTRAINT `EntityContact_FQReporting_FK` FOREIGN KEY (`FQReporting_Id`) REFERENCES `FQReporting` (`Id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+create table FQReporting_EntityContact_Name (
+  id MEDIUMINT AUTO_INCREMENT PRIMARY KEY,
+  FQReporting_EntityContact_Id MEDIUMINT NOT NULL,
+  NameType varchar(200) DEFAULT NULL,
+  Title varchar(200) DEFAULT NULL,
+  FamilyName varchar(200) DEFAULT NULL,
+  GivenName varchar(200) DEFAULT NULL,
+  MiddleName varchar(200) DEFAULT NULL,
+  FamilyNameFirst varchar(200) DEFAULT NULL,
+  PreferredFamilyName varchar(200) DEFAULT NULL,
+  PreferredFamilyNameFirst varchar(200) DEFAULT NULL,
+  PreferredGivenName varchar(200) DEFAULT NULL,
+  Suffix varchar(200) DEFAULT NULL,
+  FullName varchar(200) DEFAULT NULL,
+  INDEX `Name_FQReportingEntityContact_IX` (`FQReporting_EntityContact_Id`),
+  CONSTRAINT `Name_FQReportingEntityContact_FK` FOREIGN KEY (`FQReporting_EntityContact_Id`) REFERENCES `FQReporting_EntityContact` (`Id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+create table FQReporting_EntityContact_Address (
+  id MEDIUMINT AUTO_INCREMENT PRIMARY KEY,
+  FQReporting_EntityContact_Id MEDIUMINT NOT NULL,
+  AddressType varchar(200) DEFAULT NULL,
+  AddressRole varchar(200) DEFAULT NULL,
+  EffectiveFromDate varchar(200) DEFAULT NULL,
+  EffectiveToDate varchar(200) DEFAULT NULL,
+  Street_Line1 varchar(200) DEFAULT NULL,
+  Street_Line2 varchar(200) DEFAULT NULL,
+  Street_Line3 varchar(200) DEFAULT NULL,
+  Street_Complex varchar(200) DEFAULT NULL,
+  Street_StreetNumber varchar(200) DEFAULT NULL,
+  Street_StreetPrefix varchar(200) DEFAULT NULL,
+  Street_StreetName varchar(200) DEFAULT NULL,
+  Street_StreetType varchar(200) DEFAULT NULL,
+  Street_StreetSuffix varchar(200) DEFAULT NULL,
+  Street_ApartmentType varchar(200) DEFAULT NULL,
+  Street_ApartmentNumberPrefix varchar(200) DEFAULT NULL,
+  Street_ApartmentNumber varchar(200) DEFAULT NULL,
+  Street_ApartmentNumberSuffix varchar(200) DEFAULT NULL,
+  City varchar(200) DEFAULT NULL,
+  StateProvince varchar(200) DEFAULT NULL,
+  Country varchar(200) DEFAULT NULL,
+  PostalCode varchar(200) DEFAULT NULL,
+  GridLocation_Latitude varchar(200) DEFAULT NULL,
+  GridLocation_Longitude varchar(200) DEFAULT NULL,
+  MapReference_Type varchar(200) DEFAULT NULL,
+  MapReference_XCoordinate varchar(200) DEFAULT NULL,
+  MapReference_YCoordinate varchar(200) DEFAULT NULL,
+  RadioContact varchar(200) DEFAULT NULL,
+  Community varchar(200) DEFAULT NULL,
+  LocalId varchar(200) DEFAULT NULL,
+  AddressGlobalUID varchar(200) DEFAULT NULL,
+  INDEX `Address_FQReportingEntityContact_IX` (`FQReporting_EntityContact_Id`),
+  CONSTRAINT `Address_FQReportingEntityContact_FK` FOREIGN KEY (`FQReporting_EntityContact_Id`) REFERENCES `FQReporting_EntityContact` (`Id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+  
+create table FQReporting_EntityContact_Address_StatisticalArea (
+  id MEDIUMINT AUTO_INCREMENT PRIMARY KEY,
+  FQReporting_EntityContact_Address_Id MEDIUMINT NOT NULL,
+  spatialUnitType varchar(200) DEFAULT NULL,
+  statisticalArea varchar(200) DEFAULT NULL,
+  INDEX `StatArea_FQReportingEntityContactAddress_IX` (`FQReporting_EntityContact_Address_Id`),
+  CONSTRAINT `StatArea_FQReportingEntityContactAddress_FK` FOREIGN KEY (`FQReporting_EntityContact_Address_Id`) REFERENCES `FQReporting_EntityContact_Address` (`Id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+create table FQReporting_ContextualQuestion (
+  id MEDIUMINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  FQReporting_Id MEDIUMINT NOT NULL,
+  Context varchar(200) DEFAULT NULL,
+  Answer varchar(200) DEFAULT NULL,
+  INDEX `ContextualQuestion_FQReporting_IX` (`FQReporting_Id`),
+  CONSTRAINT `ContextualQuestion_FQReporting_FK` FOREIGN KEY (`FQReporting_Id`) REFERENCES `FQReporting` (`Id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+create table FQReporting_FQItem (
+  id MEDIUMINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  FQReporting_Id MEDIUMINT NOT NULL,
+  FQItemCode varchar(200) DEFAULT NULL,
+  TuitionAmount varchar(200) DEFAULT NULL,
+  BoardingAmount varchar(200) DEFAULT NULL,
+  SystemAmount varchar(200) DEFAULT NULL,
+  DioceseAmount varchar(200) DEFAULT NULL,
+  FQComments varchar(200) DEFAULT NULL,
+  INDEX `FQItem_FQReporting_IX` (`FQReporting_Id`),
+  CONSTRAINT `FQItem_FQReporting_FK` FOREIGN KEY (`FQReporting_Id`) REFERENCES `FQReporting` (`Id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE FQReporting_AGRule (
+   Id MEDIUMINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+   FQReporting_Id MEDIUMINT NOT NULL,
+   AGRuleCode VARCHAR(200),
+   AGRuleComment VARCHAR(200),
+   AGRuleResponse VARCHAR(200),
+   AGRuleStatus VARCHAR(200),
+   INDEX `Rule_FQReporting_IX` (`FQReporting_Id`),
+   CONSTRAINT `Rule_FQReporting_FK` FOREIGN KEY (`FQReporting_Id`) REFERENCES `FQReporting` (`Id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
Changes for datamodel 3.4.4.

I have included `schema/migrations/v2.7.0-v2.8.0.sql`so that v2.7.0 databases can be migrated to the current version.

Completes #419