### PR TITLE
AG Collections

### DIFF
--- a/bin/create_sif_data.pl
+++ b/bin/create_sif_data.pl
@@ -33,7 +33,7 @@ use Data::Dumper;
 my $sd = SIF::Data->new();
 
 my ($schools, $students, $student_contacts, $staff, $rooms, $groups,
-	$grading, $account, $vendors, $debtors, $fix, $codeset, $create_db,
+	$grading, $account, $vendors, $debtors, $agcollections, $fix, $codeset, $create_db,
 	$db_name, $ttable, $school_id, $elements, $fobjects, $scheduled_activities,
 	$silent) = get_args();
 
@@ -94,6 +94,8 @@ if ($ttable) {
 
 	create_grading($grading, $school_id);
 
+	create_agcollections($agcollections);
+
 	create_student_contacts($student_contacts, $school_id);
 
 	create_accounts($account);
@@ -127,6 +129,7 @@ sub get_args {
 	my $account          = undef;
 	my $vendors          = undef;
 	my $debtors          = undef;
+	my $agcollections    = undef;
 	my $fix              = undef;
 	my $codeset          = undef;
 	my $create_db        = undef;
@@ -151,6 +154,7 @@ sub get_args {
 		"create-accounts=s"        => \$account,
 		"create-vendors=s"         => \$vendors,
 		"create-debtors=s"         => \$debtors,
+		"create-agcollections"     => \$agcollections,
 		"fix"                      => \$fix,
 		"codeset"                  => \$codeset,
 		"create-database=s"        => \$create_db,
@@ -192,7 +196,7 @@ sub get_args {
 		usage_exit();
 	}
 
-	if ($create_db && $elements && (! $schools)) {
+	if ($create_db && $elements && (! $schools )) {
 		print "\nMust include create-schools when creating database and other elements\n";
 		usage_exit();
 	}
@@ -211,7 +215,7 @@ sub get_args {
 	}
 
 	return ($schools, $students, $student_contacts, $staff, $rooms,
-	$groups, $grading, $account, $vendors, $debtors, $fix, $codeset,
+	$groups, $grading, $account, $vendors, $debtors, $agcollections, $fix, $codeset,
 	$create_db, $db_name, $ttable,  $school_id, $elements, $fobjects, $scheduled_activities,
 	$silent);
 }
@@ -243,6 +247,8 @@ Sample usage is:
   ./create_sif_data.pl --create-teaching-groups # Create groups for all years and students
 
   ./create_sif_data.pl --create-debtors=8..16   # Create random 8-16 Debtors
+
+  ./create_sif_data.pl --create-agcollections   # Create AG Collections round and status reports
 
   ./create_sif_data.pl --create-scheduled-activities=8..16   # Create random 8-16 scheduled activities
 
@@ -365,6 +371,14 @@ sub create_grading {
 	if (defined $grading) {
 		make_grading($grading, $school);
 	}
+}
+
+sub create_agcollections {
+        my ($agcollections) = @_;
+
+        if (defined $agcollections) {
+                make_agcollections($agcollections);
+        }
 }
 
 sub create_student_contacts {
@@ -1486,6 +1500,100 @@ sub make_grading {
 	if ( (defined $grading) && ($num_tg_seen == 0) ) {
 		die qq(\nNo teaching groups were found.\nYou may need to run this program with the "--create-teaching-groups" options first);
 	}
+}
+
+#
+# Populate the CollectionRound and CollectionStatus tables
+#
+
+sub make_agcollections {
+        my ($grading, $school) = @_;
+
+                my $sth_collectionround = $dbh->prepare(q{
+                                        INSERT INTO CollectionRound
+                                        (
+                                                RefId,
+                                                AGCollection,
+                                                CollectionYear
+                                        )
+                                VALUES
+                                        (
+                                                ?,
+                                                ?,
+                                                ?
+                                        )
+                        });
+                 my $sth_aground = $dbh->prepare(q{
+                                INSERT INTO AGRound
+                                        (
+                                                CollectionRoundRefId, RoundCode, RoundName,
+                                                StartDate, DueDate, EndDate
+                                        )
+                                VALUES
+                                        (
+                                                ?, ?, ?, ?, ?, ?
+                                        )
+                   });
+                   my $sth_collectionstatus = $dbh->prepare(q{
+                                INSERT INTO CollectionStatus
+                                        (
+                                                RefId, ReportingAuthority, ReportingAuthoritySystem,
+                                                ReportingAuthorityCommonwealthId, SubmittedBy,
+                                                SubmissionTimestamp, AGCollection, CollectionYear, RoundCode
+                                        )
+                                VALUES
+                                        (
+                                                ?, ?, ?, ?, ?, ?, ?, ?, ?
+                                        )
+                   });
+                   my $sth_objectresponse = $dbh->prepare(q{
+                                INSERT INTO AGReportingObjectResponse
+                                        (
+                                                CollectionStatusRefId, SubmittedRefId, SIFRefId, 
+                                                HTTPStatusCode, ErrorText, CommonwealthId, 
+                                                EntityName, AGSubmissionStatusCode
+                                        )
+                                VALUES
+                                        (
+                                                ?, ?, ?, ?, ?, ?, ?, ?
+                                        )
+                   });
+                   my $sth_agrule = $dbh->prepare(q{
+                                INSERT INTO AGRule
+                                        (
+                                                ReportingObjectResponseRecordNumber, AGRuleCode, 
+                                                AGRuleComment, AGRuleResponse, AGRuleStatus
+
+                                        )
+                                VALUES
+                                        (
+                                                ?, ?, ?, ?, ?
+                                        )
+                   });
+
+
+
+
+        foreach $type qw(COI FQ SES STATS) {
+                 my @values = $sd->create_collection_rounds($type);
+                 $sth_collectionround->execute( @values );
+                 my $roundrefid = $values[0];
+                 foreach my $roundnumber (1..2) {
+                        my @values = $sd->create_collection_round_list_item($roundrefid, $type, $roundnumber);
+                        $sth_aground->execute( @values );
+                        my @values2 = $sd->create_collection_status($type, $roundnumber);
+                        $sth_collectionstatus->execute( @values2 );
+                        my $collectionstatusrefid = $values2[0];
+                        my @values3 = $sd->create_reporting_object_response($collectionstatusrefid, $type, $roundnumber);
+                        $sth_objectresponse->execute( @values3 );
+                        my $reportingobjectrecordnumber = $values3[1];
+                        foreach my $rulenumber (1..3) {
+                            my @values = $sd->create_agrule($reportingobjectrecordnumber, sprintf("WR-%03d", $rulenumber));
+                            $sth_agrule->execute( @values );
+
+                        }
+                 }
+        }
 }
 
 sub num_teaching_groups {

--- a/lib/SIF/Data.pm
+++ b/lib/SIF/Data.pm
@@ -1054,11 +1054,7 @@ sub create_reporting_object_response {
                 "Accepted",
                 "101",
                 "Middleton Primary School",
-                "In Progress",
-                make_this_year() + sprintf("-%02d-%02d", $roundnumber * 2 + 6, 1),
-                $type,
-                make_this_year(),
-                $type . $roundnumber,
+                "In Progress"
         );
 }
 

--- a/lib/SIF/Data.pm
+++ b/lib/SIF/Data.pm
@@ -982,9 +982,9 @@ sub create_collection_round_list_item {
                 $collectionroundrefid, 
                 $type . $roundnumber,
                 %collectionname{$type} . " " . $roundnumber,
-                make_this_year() + sprintf("-%02d-%02d", $roundnumber * 2 + 5, int(rand(20))),
-                make_this_year() + sprintf("-%02d-%02d", $roundnumber * 2 + 6, int(rand(20))),
-                make_this_year() + sprintf("-%02d-%02d", $roundnumber * 2 + 8, int(rand(20))),
+                make_this_year() + sprintf("-%02d-%02d", $roundnumber * 2 + 5, int(rand(20)+1)),
+                make_this_year() + sprintf("-%02d-%02d", $roundnumber * 2 + 6, int(rand(20)+1)),
+                make_this_year() + sprintf("-%02d-%02d", $roundnumber * 2 + 8, int(rand(20)+1)),
         );
 }
 

--- a/lib/SIF/Data.pm
+++ b/lib/SIF/Data.pm
@@ -919,6 +919,194 @@ sub create_OtherCode {
 	return ($code0, $code1);
 }
 
+=head2 Create Collection Rounds
+
+  my $sth = $dbh->prepare(q{
+        INSERT INTO CollectionRound
+                (
+                        RefId, AGCollection, CollectionYear
+                )
+        VALUES
+                (
+                        ?, ?, ?
+                )
+  });
+  $sth2->execute( $sd->create_collection_rounds($stId, $type));
+
+  $type: type of AG collection
+
+=cut
+
+sub create_collection_rounds {
+        my ($self, $type) = @_;
+
+        return (
+                make_new_id(),
+                $type,
+                make_this_year()
+        );
+}
+
+my %collectionname = (
+  "COI" => "Non-Government Schools Census",
+  "FQ" => "Financial Questionnaire",
+  "SES" => "Address Collection",
+  "STATS" => "Student Attendance (STATS)",
+);
+
+=head2 Create Collection Round list
+
+ my $sth = $dbh->prepare(q{
+        INSERT INTO AGRound
+                (
+                        CollectionRoundRefId, RoundCode, RoundName, StartDate, DueDate, EndDate
+                )
+        VALUES
+                (
+                        ?, ?, ?, ?, ?, ?
+                )
+  });
+  $sth2->execute( $sd->create_collection_round_list_item($collectionroundrefid, $type, $roundnumber));
+
+  $collectionroundrefid: RefID of parent CollectionRound object
+  $type: type of AG collection
+  $roundnumber: number of round
+
+  Assume two rounds a year
+=cut
+
+sub create_collection_round_list_item {
+        my ($self, $collectionroundrefid, $type, $roundnumber) = @_;
+
+        return (
+                $collectionroundrefid, 
+                $type . $roundnumber,
+                %collectionname{$type} . " " . $roundnumber,
+                make_this_year() + sprintf("-%02d-%02d", $roundnumber * 2 + 5, int(rand(20))),
+                make_this_year() + sprintf("-%02d-%02d", $roundnumber * 2 + 6, int(rand(20))),
+                make_this_year() + sprintf("-%02d-%02d", $roundnumber * 2 + 8, int(rand(20))),
+        );
+}
+
+=head2 Create Collection Status
+
+ my $sth = $dbh->prepare(q{
+        INSERT INTO CollectionStatus
+                (
+                        RefId, ReportingAuthority, ReportingAuthoritySystem, ReportingAuthorityCommonwealthId, SubmittedBy, SubmissionTimestamp, AGCollection, CollectionYear, RoundCode
+                )
+        VALUES
+                (
+                        ?, ?, ?, ?, ?, ?, ?, ?, ?
+                )
+  });
+  $sth2->execute( $sd->create_collection_round_list_item($type, $roundnumber));
+
+  $type: type of AG collection
+  $roundnumber: number of round
+=cut
+
+sub create_collection_status {
+        my ($self, $type, $roundnumber) = @_;
+
+        return (
+                make_new_id(),
+                "Middleton Primary School Reporting Authority",
+                "",
+                "1",
+                "John Smith",
+                make_this_year() + sprintf("-%02d-%02d", $roundnumber * 2 + 6, 1),
+                $type,
+                make_this_year(),
+                $type . $roundnumber,
+        );
+}
+
+=head2 Create Reporting Object Response
+
+ my $sth = $dbh->prepare(q{
+        INSERT INTO AGReportingObjectResponse
+                (
+                        CollectionStatusRefId, ReportingObjectResponseRecordNumber, SubmittedRefId, SIFRefId, HTTPStatusCode, ErrorText, CommonwealthId, EntityName, AGSubmissionStatusCode
+                )
+        VALUES
+                (
+                        ?, ?, ?, ?, ?, ?, ?, ?, ?
+                )
+  });
+  $sth2->execute( $sd->create_reporting_object_response($collectionstatusrefid, $type, $roundnumber));
+
+  $collectionstatusrefid: RefID of parent CollectionStatus object
+  $type: type of AG collection
+  $roundnumber: number of round
+=cut
+
+# Note: we are not updating this object dynamically to link to a submitted collection record; the RefIds returned are dummies.
+sub create_reporting_object_response {
+        my ($self, $collectionstatusrefid, $type, $roundnumber) = @_;
+
+        return (
+                $collectionstatusrefid, 
+                make_new_id(),
+                make_new_id(),
+                make_new_id(),
+                "202",
+                "Accepted",
+                "101",
+                "Middleton Primary School",
+                "In Progress",
+                make_this_year() + sprintf("-%02d-%02d", $roundnumber * 2 + 6, 1),
+                $type,
+                make_this_year(),
+                $type . $roundnumber,
+        );
+}
+
+=head2 Create AGRule
+
+ my $sth = $dbh->prepare(q{
+        INSERT INTO AGRule
+                (
+                        ReportingObjectResponseRecordNumber, AGRuleCode, AGRuleComment, AGRuleResponse, AGRuleStatus
+                )
+        VALUES
+                (
+                        ?, ?, ?, ?, ?
+                )
+  });
+  $sth2->execute( $sd->create_agrule($reportingobjectrecordnumber, $rulecode));
+
+  $reportingobjectrecordnumber: Record Number in database of Reporting Object Response
+  $rulecode: AG Rule Code
+=cut
+
+# Note: we are not updating this object dynamically to link to a submitted collection record; the reported rules are dummies.
+sub create_agrule {
+        my ($self, $reportingobjectrecordnumber, $rulecode) = @_;
+
+        return (
+                $reportingobjectrecordnumber,
+                $rulecode,
+                "Cannot be ignored because Components do not add up to Total - Fix",
+                "Rejected",
+                "Fail"
+        );
+}
+
+
+
+sub create_calendar {
+        my ($self, $data) = @_;
+
+        $data->{refid}          = $self->make_new_id();
+        $data->{schoolyear}     = make_this_year();
+        $data->{daysinsession}  = 67+67+68+75;
+        $data->{startdate}      = $data->{schoolyear} . '-01-28';
+        $data->{enddate}        = $data->{schoolyear} . '-12-19';
+
+        return $data;
+}
+
 
 =head2 Create Calendar elements
 


### PR DESCRIPTION
This PR will not work yet, because I have no idea what the schema is for the AG objects. Moreover, even if I did know what the AG objects are, the lines

````
use lib "/var/sif/sif-data/lib";
use lib "/home/ubuntu/perl5/lib/perl5";
````

make it doubtful I will be able to run the script on my machine to test it; that means that any testing and debugging will have to be done by you on the metal.

When the schema for the CollectionRound and CollectionStatus objects is ready, we can update this, but I don't anticipate major changes.

The dummy objects are well and truly dummy, and we may need to make them more realistic; but having CollectionStatus objects generated dynamically, even if it is only to reference the GUIDs of submitted collections, is a bigger chunk of workflow than I think we should be taking on in HITS.